### PR TITLE
fix load balancer ip creation - fix #33

### DIFF
--- a/docker/tezos-remote-signer-forwarder/Dockerfile.template
+++ b/docker/tezos-remote-signer-forwarder/Dockerfile.template
@@ -22,10 +22,6 @@ RUN cat /etc/ssh/sshd_config
 
 RUN mkdir /home/signer/.ssh && chown -R signer /home/signer
 
-#8433 is remote signer port
-#58255 is ssh port
-EXPOSE 8433 58255
-
 COPY tezos-remote-signer-forwarder.sh /
 COPY configGenerator.py /
 ENTRYPOINT ["/tezos-remote-signer-forwarder.sh"]

--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -51,7 +51,7 @@ EOF
 
 # Provision IP for signer forwarder endpoint if there is at least one occurence of "authorized_signers" data in the bakers map
 resource "google_compute_address" "signer_forwarder_target" {
-  count = length(lookup((merge(merge(values(merge(merge(values(var.baking_nodes)...),{}))...),{})), "authorized_signers", []))
+  count = length(lookup((merge(merge(values(merge(merge(values(var.baking_nodes)...),{}))...),{})), "authorized_signers", [])) > 0 ? 1 : 0
   name    = "tezos-baker-lb"
   region  = module.terraform-gke-blockchain.location
   project = module.terraform-gke-blockchain.project


### PR DESCRIPTION
if you have more than one remote signer for a given baking address, count will come up as 2 or more.

The same LB IP is used for every signer (but different port), so we limit the possibilities to zero or one.