### PR TITLE
put trd report file in a bucket for analysis

### DIFF
--- a/docker/payout-report-uploader/Dockerfile.template
+++ b/docker/payout-report-uploader/Dockerfile.template
@@ -1,0 +1,8 @@
+FROM google/cloud-sdk:slim
+
+COPY entrypoint.sh /payout-report-uploader/
+
+ENTRYPOINT ["/payout-report-uploader/entrypoint.sh"]
+
+CMD []
+

--- a/docker/payout-report-uploader/entrypoint.sh
+++ b/docker/payout-report-uploader/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -x
+# workload identity allows this to work
+gcloud container clusters get-credentials blockchain --region $GCP_REGION
+
+cd /app/reports
+
+find
+
+echo "now rsyncing payout reports to $REPORT_BUCKET_URL"
+gsutil -m rsync /app/reports $REPORT_BUCKET_URL

--- a/docker/payout-report-uploader/entrypoint.sh
+++ b/docker/payout-report-uploader/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -x
-# workload identity allows this to work
-gcloud container clusters get-credentials blockchain --region $GCP_REGION
 
-cd /app/reports
-
-find
+find /app/reports
 
 echo "now rsyncing payout reports to $REPORT_BUCKET_URL"
-gsutil -m rsync /app/reports $REPORT_BUCKET_URL
+# workload identity allows this to work
+gsutil -m rsync -r /app/reports $REPORT_BUCKET_URL
+
+echo "Done"
+echo ""

--- a/k8s/payout-base/trd-payout.yaml
+++ b/k8s/payout-base/trd-payout.yaml
@@ -24,7 +24,7 @@ spec:
         spec:
           securityContext:
             fsGroup: 100
-          containers:
+          initContainers:
           - name: trd-payout-cron
             image: trd
               #command: ["/bin/sh", "-ec", "sleep 1000"]
@@ -38,6 +38,20 @@ spec:
             resources:
               limits:
                 cpu: 0
+          containers:
+          - name: report-uploader
+            image: payout-report-uploader
+            volumeMounts:
+            - name: trd-reports
+              mountPath: /app/reports
+              readOnly: true
+            imagePullPolicy: Always
+            resources:
+              limits:
+                cpu: 0
+            envFrom:
+            - configMapRef:
+                name: report-upload-config
           volumes:
           - name: trd-reports
             persistentVolumeClaim:
@@ -49,6 +63,7 @@ spec:
               - key: config.yaml
                 path: config.yaml
           restartPolicy: OnFailure
+          serviceAccountName: trd-report-uploader
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -68,3 +83,8 @@ spec:
     - podSelector:
         matchLabels:
           app: trd-payout-sender
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trd-report-uploader

--- a/k8s/payout-tmpl/kustomization.yaml.tmpl
+++ b/k8s/payout-tmpl/kustomization.yaml.tmpl
@@ -10,13 +10,21 @@ imageTags:
   - name: trd
     newName: registry.gitlab.com/ochem/tezos-reward-distributor
     newTag: latest
+  - name: payout-report-uploader
+    newName: gcr.io/${project}/payout-report-uploader
+    newTag: ${kubernetes_namespace}-latest
 
 configMapGenerator:
 - name: trd-config
   files:
   - config.yaml
+- name: report-upload-config
+  literals:
+  - GCP_REGION="${region}"
+  - REPORT_BUCKET_URL="${report_bucket_url}"
 
 patchesStrategicMerge:
 - crontime.yaml
 - nodepool.yaml
 - trd-args.yaml
+- serviceaccountannotate.yaml

--- a/k8s/payout-tmpl/serviceaccountannotate.yaml.tmpl
+++ b/k8s/payout-tmpl/serviceaccountannotate.yaml.tmpl
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trd-report-uploader
+  annotations:
+    iam.gke.io/gcp-service-account: ${kubernetes_name_prefix}-payout-report-uploader@${project}.iam.gserviceaccount.com

--- a/k8s/payout-tmpl/trd-args.yaml.tmpl
+++ b/k8s/payout-tmpl/trd-args.yaml.tmpl
@@ -7,7 +7,7 @@ spec:
     spec:
       template:
         spec:
-          containers:
+          initContainers:
           - name: trd-payout-cron
             args:
             - "--run_mode"


### PR DESCRIPTION
it makes it easy to do development work on TRD and gives users an easy
way to access detailed csv payment files

bucket names are randomized, and we use workload identity to give bucket
write rights to containers.